### PR TITLE
Add AGENTS.md for Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project overview
+
+Sturmfrei company website — a static marketing site built with **Astro v5**, **Tailwind CSS**, and **TypeScript**. No backend services, databases, or external dependencies required for local development.
+
+### Available commands
+
+See the `scripts` section in `package.json` and the README for the full list. Key commands:
+
+| Command | Purpose |
+|---|---|
+| `npm run dev` | Start dev server on port 4321 (with `--host` for network access) |
+| `npm run build` | Production build to `./dist/` |
+| `npm run lint:eslint` | Run ESLint |
+| `npm run format` | Format with Prettier |
+
+### Caveats
+
+- **Pre-existing lint error:** `Hero2.astro` has an unused `Background` import that triggers an ESLint error. This is in the existing codebase and should not block work.
+- **Tailwind config warning:** During build, a warning appears about `tailwind.config.cjs` and ES module loading. This is cosmetic and does not affect the build output.
+- **No `.env` required:** The site runs fully without environment variables.
+- **Content:** Blog posts are MDX files in `src/content/post/`. The CMS (Decap CMS) requires external git-gateway auth and is not needed for local development.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud specific development instructions for future cloud agents.

### What's included

- Project overview (Astro v5 static site, no backend/DB dependencies)
- Key development commands (dev, build, lint, format)
- Non-obvious caveats discovered during setup:
  - Pre-existing ESLint error in `Hero2.astro` (unused import)
  - Tailwind config warning during build (cosmetic only)
  - No `.env` needed for local development
  - Decap CMS not required for local dev

### Environment verification

All commands verified working:

- `npm install` — installs 798 packages
- `npm run lint:eslint` — runs successfully (1 pre-existing error)
- `npm run build` — builds 12 pages to `dist/`
- `npm run dev` — dev server starts on port 4321

### Demo

<a href="https://cursor.com/agents/bc-21729f92-8d07-4ff2-8918-d5e9727b0430/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsturmfrei_site_demo.mp4"><img src="https://cursor.com/artifacts/c/art-b8798eeb-e78d-425d-891e-66dd9f1c2e58" alt="sturmfrei_site_demo.mp4" /></a>

![Homepage hero section](https://cursor.com/artifacts/c/art-d4e70a6e-f5e8-4997-a7ab-646b35bf6c41)
![About page](https://cursor.com/artifacts/c/art-e99778d5-bc31-4a37-b753-b33eecb2f6ac)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21729f92-8d07-4ff2-8918-d5e9727b0430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21729f92-8d07-4ff2-8918-d5e9727b0430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

